### PR TITLE
Docker pull latest version

### DIFF
--- a/fpfilter.cwl.yaml
+++ b/fpfilter.cwl.yaml
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 baseCommand: [perl, /opt/fpfilter.pl, --output, fpfilter.vcf]
 requirements:
   - class: "DockerRequirement"
-    dockerImageId: "opengenomics/fpfilter:0.0.1"
+    dockerPull: "opengenomics/fpfilter:latest"
 inputs:
   vcf-file:
     type: File


### PR DESCRIPTION
I'm thinking that it's useful to have the master branch have docker image versions of "latest". This makes it easy to develop and rebuild images, and to commit those fixes and have the version match docker hub.

Specific versions should be set when a tool/workflow is tagged in git (and therefore docker hub).
